### PR TITLE
Disabled Deep Watcher

### DIFF
--- a/src/components/Moveable.vue
+++ b/src/components/Moveable.vue
@@ -17,7 +17,7 @@ const watchReactiveProp = (key, deep) => ({
 });
 
 const watchMoveableProps = () => PROPERTIES.reduce((acc, prop) => {
-  acc[prop] = watchReactiveProp(prop, true);
+  acc[prop] = watchReactiveProp(prop, false);
   return acc;
 }, {});
 


### PR DESCRIPTION
Deep Watcher isn't required for functionality from my testing and can cause issues if mounted into a parent site with a large code base.